### PR TITLE
typo in rgba

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,8 +23,7 @@ body {
       cursor: pointer;
       font-size: 2rem;
       border: 1px, solid #FFFFFF;
-      outline: none;
-      background-color: rbga(255, 255, 255, 0.75);
+      outline: none;     
     }
 
       .calculator-grid > button:hover {


### PR DESCRIPTION
The background-color line has a typo on it. If this typo was fixed, because of the priority in the css selector, it makes the background-color change to the "All Clear" and "equals" signs non-existent. So this line is redundant.